### PR TITLE
Add `bower install` to `postinstall` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Install these if you haven't yet:
 Now from inside the project folder, install the local requirements:
 
     npm install
-    bower install
 
 For the [HTML Imports](http://www.polymer-project.org/platform/html-imports.html) polyfill of Polymer to work, the app has to be served on a local web server. You can use whatever web server you prefer to serve the files. For example:
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "rimraf": "^2.2.8",
     "yargs": "^1.3.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "postinstall": "bower install"
+  }
 }


### PR DESCRIPTION
This PR makes use of the https://docs.npmjs.com/cli/run-script property in your `package.json`, and now whenever someone runs `npm install` in the project directory, once it is completed, `bower install` will be run as well. This means we can go from git clone to installed project in only two steps, instead of 3, and is part of a longer series of PRs I intend to propose to make getting set up easier, and less reliant on external dependencies outside of node and npm.

Stage 1 of #27