### PR TITLE
Add bower to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Padlock",
   "version": "0.0.0",
   "devDependencies": {
+    "bower": "^1.6.5",
     "gulp": "^3.9.0",
     "gulp-crisper": "0.0.5",
     "gulp-insert-lines": "0.0.4",


### PR DESCRIPTION
This PR specifies the version of bower that someone who wants to build the project will use, and combined with #26, it allows us to drop telling people that bower needs to be installed globally, and should make troubleshooting newer versions of bower easier, because we can test them in isolation before updating the `package.json`.

Stage 2 of #27 