### PR TITLE
add serve script + dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-vulcanize": "^6.0.1",
     "gulp-watch": "^0.6.9",
     "jshint-stylish": "^0.4.0",
+    "live-server": "^0.8.2",
     "mkdirp": "^0.5.0",
     "ncp": "^0.6.0",
     "nib": "^1.0.3",
@@ -18,5 +19,8 @@
     "rimraf": "^2.2.8",
     "yargs": "^1.3.1"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "server": "live-server ."
+  }
 }


### PR DESCRIPTION
This script adds a default, live-reloading server, and aliases the command to start it to `npm run server`. I'm no gulp expert, so I'm more than happy to defer this one, it's a little nicety I've found helpful when I've been running the project locally.

The final step in #27 