### PR TITLE
Use `npm run <cmd>` for various dev actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ A minimal open source password manager built with [Polymer](http://www.polymer-p
 Install these if you haven't yet:
 
 - [Node.js and npm](http://nodejs.org/)
-- [Gulp](http://gulpjs.com/)
-- [Bower](http://bower.io/)
 
 Now from inside the project folder, install the local requirements:
 
     npm install
-    bower install
+    npm run bower
 
 For the [HTML Imports](http://www.polymer-project.org/platform/html-imports.html) polyfill of Polymer to work, the app has to be served on a local web server. You can use whatever web server you prefer to serve the files. For example:
 
@@ -22,17 +20,17 @@ For the [HTML Imports](http://www.polymer-project.org/platform/html-imports.html
 
 Padlock uses the [Stylus](http://learnboost.github.io/stylus/) as a CSS preprocessor. Most style sheets are maintained as `.styl` files and compiled locally. To compile all `.styl` files to CSS, run the corresponding gulp task
 
-    gulp stylus
+    npm run stylus
 
 You can also use the `--watch` flag to tell the gulp task to watch all `.styl` files and recompile them whenever any of them changes.
 
-    gulp stylus --watch
+    npm run stylus --watch
 
 ## Linting
 
 Any pull request need to pass our linting rules, which are defined in the `.eslintrc.json` file. To lint all files, run
 
-    gulp eslint
+    npm run gulp eslint
 
 ## Testing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ gulp.task("stylus", function() {
 });
 
 gulp.task("eslint", function() {
-    tools.eslint();
+    tools.runEslint();
 });
 
 // Deploy a minified/built version of the app to a given destination folder

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "Padlock",
   "version": "1.0.0",
   "main": "tools.js",
+  "scripts": {
+    "bower": "bower install",
+    "gulp": "gulp",
+    "stylus": "gulp stylus",
+    "deploy": "gulp deploy"
+  },
   "devDependencies": {
+    "bower": "^1.8.0",
     "eslint-plugin-html": "^1.5.1",
     "gulp": "^3.9.1",
     "gulp-crisper": "1.1.0",


### PR DESCRIPTION
Looks like `gulp eslint` was already broken. While fixing that, I also
removed the need to have gulp installed globally. Instead we can use
npm scripts section to run the same commands.