### PR TITLE
Fix windows builds by explicitly invoking 'node' to execute polymer-bundler

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -117,7 +117,7 @@ function bundle(dest = "build") {
     const bundler = `${projectRoot}/node_modules/polymer-bundler/lib/bin/polymer-bundler.js`;
     return rmdir(dest)
         .then(() => copyFiles(appDir, dest, ["assets"]))
-        .then(() => pexec(`${bundler} --inline-scripts --inline-css -r ${appDir} index.html > ${dest}/index.html`));
+        .then(() => pexec(`node ${bundler} --inline-scripts --inline-css -r ${appDir} index.html > ${dest}/index.html`));
 }
 
 function buildChrome() {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "build:mac": "gulp build --mac --silent",
     "build:win": "gulp build --win --silent",
     "build:linux": "gulp build --linux --silent",
-    "postinstall": "npm run bower-install && npm run compile && mkdir cordova/www"
+    "postinstall": "npm run bower-install && npm run compile && mkdir -p cordova/www"
   }
 }


### PR DESCRIPTION
Additionally, use `mkdir -p cordova/www` to create the needed directory to prevent the script from erroring out if the directory already exists.