### PR TITLE
Add note and link about padlock as "padloc v2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # padlock
 DEPRECATED: new repository ==> https://github.com/padloc/padloc
+
+But, if you are looking for the last version of "Padlock" (i.e. v2), that's still open source here: https://github.com/padloc/padloc/tree/v2.7.2.


### PR DESCRIPTION
I was shocked (and appalled) for about 24 hours while I thought you deleted the old repo entirely (which would undermine the open source spirit). But, then I realized that it just moved and could be found in the history of the new padloc repo.

Thanks for not being evil. Hopefully this note helps reassure others quicker. ;)